### PR TITLE
WIP: Add base workflow for mail-to-sheet agent

### DIFF
--- a/01-weekly-report/agents/01_mail_to_sheets/README.md
+++ b/01-weekly-report/agents/01_mail_to_sheets/README.md
@@ -1,0 +1,77 @@
+# 수신 메일 정리 에이전트 (Mail-to-Sheet Agent)
+
+이 에이전트는 Kakao로 수신된 메일을 파싱하여 **구글 시트에 자동으로 정리**하는 역할을 합니다.  
+
+---
+
+## ✨ 주요 기능
+
+- **메일 본문 파싱**
+
+  - 본문에서 `어제 한 일 (Did)`, `오늘 할 일 (To-Do)`, `문제 (Problem)` 항목 자동 추출
+  - `:`, `-`, 줄바꿈 등 다양한 입력 포맷을 지원
+
+- **보낸 사람 정보 분리**
+
+  - `from` 값을 이름과 이메일로 분리  
+
+  - 예:  
+
+    ```
+    신영태 <youngtae0818@naver.com>
+    → name: 신영태, email: youngtae0818@naver.com
+    ```
+
+- **날짜 표준화**
+
+  - 메일 원본 날짜(`Mon, 29 Sep 2025 ...`)를 ISO 형식(`2025-09-29`)으로 변환  
+  - n8n의 `$today`와 쉽게 비교 가능
+
+- **구글 시트 연동**
+
+  - 파싱된 업무 내용을 `주간업무보고 시트`에 기록
+  - 신규 인원은 자동으로 `마스터 명단 시트`에 추가하거나 기존 인원 정보 업데이트
+
+---
+
+## 🛠 워크플로우 흐름
+
+1. **이메일 수신 (Email Trigger)**  
+   - IMAP 기반 Email Trigger (Kakao) 또는 Gmail Trigger 사용  
+2. **업무 내용 파싱 (Parse Work Report Content)**  
+   - 본문에서 Did / To-Do / Problem 추출  
+3. **보낸 사람 정보 추출 (Extract Name and Email)**  
+   - 이름/이메일로 분리  
+4. **주간업무보고 시트 기록 (Append Weekly Report)**  
+   - 추출된 데이터를 구글 시트에 행으로 추가  
+5. **마스터 명단 업데이트 (Update Master Roster)**  
+   - 신규 인원은 자동 추가, 기존 인원은 이메일 갱신
+
+---
+
+## 📊 구글 시트 구조
+
+### 주간업무보고 시트
+
+| name   | email                  | date       | did                      | todo                   | problem                                     |
+| ------ | ---------------------- | ---------- | ------------------------ | ---------------------- | ------------------------------------------- |
+| 신영태 | youngtae0818@naver.com | 2025-09-29 | n8n 사용법 데이터 다루기 | n8n 이메일 자동화 학습 | n8n email trigger와 gmail trigger 차이 모름 |
+
+### 마스터 명단 시트
+
+| name   | email                  |
+| ------ | ---------------------- |
+| 김설화 | seolhwa@example.com    |
+| 신영태 | youngtae0818@naver.com |
+| 김영광 | glory@example.com      |
+
+---
+
+## 🚀 사용 방법
+
+1. 제공된 JSON 파일을 n8n에서 `Workflow → Import from File`로 불러오기  
+2. 아래 크리덴셜을 설정  
+   - **Email Trigger**: Kakao(IMAP) 또는 Gmail(OAuth2)  
+   - **Google Sheets**: OAuth2 인증  
+3. Google Sheets 노드에서 **사용할 시트 이름/ID** 업데이트  
+4. 워크플로우 실행 → 수신 메일이 자동으로 파싱되어 시트에 기록됨

--- a/01-weekly-report/agents/01_mail_to_sheets/mail_to_sheet_parser.json
+++ b/01-weekly-report/agents/01_mail_to_sheets/mail_to_sheet_parser.json
@@ -1,0 +1,256 @@
+{
+  "name": "수신 메일 구글시트에 정리하는 에이전트",
+  "nodes": [
+    {
+      "parameters": {
+        "options": {}
+      },
+      "type": "n8n-nodes-base.emailReadImap",
+      "typeVersion": 2.1,
+      "position": [
+        -384,
+        -176
+      ],
+      "id": "1b5ec832-91b3-4e27-898c-febebd99650b",
+      "name": "Fetch Incoming Email",
+      "credentials": {
+        "imap": {
+          "id": "W4woBrOjXo1lIGJk",
+          "name": "IMAP account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const body = $input.first().json.textPlain || \"\";\nconst lines = body.split(\"\\n\").map(l => l.trim());\n\nlet did = \"\";\nlet todo = \"\";\nlet problem = \"\";\n\n// 본문 파싱 함수\nfunction extractContent(line, nextLine) {\n  if (line.includes(\":\")) {\n    return line.split(\":\").slice(1).join(\":\").trim();\n  }\n  if (nextLine && nextLine.startsWith(\"-\")) {\n    return nextLine.replace(/^-/, \"\").trim();\n  }\n  if (nextLine) {\n    return nextLine.trim();\n  }\n  return \"\";\n}\n\nfor (let i = 0; i < lines.length; i++) {\n  const line = lines[i];\n  const nextLine = lines[i + 1];\n\n  if (line.startsWith(\"1.\") || line.includes(\"(Did)\")) {\n    did = extractContent(line, nextLine);\n  } else if (line.startsWith(\"2.\") || line.includes(\"(TO-Do)\")) {\n    todo = extractContent(line, nextLine);\n  } else if (line.startsWith(\"3.\") || line.includes(\"(Problem)\")) {\n    problem = extractContent(line, nextLine);\n  }\n}\n\n// 보낸 사람 파싱 (이름 / 이메일)\nconst from = $input.first().json.from || \"\";\nlet name = \"\";\nlet email = \"\";\n\nconst match = from.match(/(.*)<(.*)>/);\nif (match) {\n  name = match[1].trim();\n  email = match[2].trim();\n} else {\n  email = from.trim();\n}\n\n// 날짜 변환 (YYYY-MM-DD)\nconst rawDate = new Date($input.first().json.date);\nconst date = rawDate.toISOString().split(\"T\")[0];\n\nreturn [{\n  json: {\n    name,\n    email,\n    date,   // 변환된 날짜\n    did,\n    todo,\n    problem,\n  }\n}];\n"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -176,
+        -176
+      ],
+      "id": "f214c1aa-d203-4219-be4b-081e2788d22b",
+      "name": "Parse Work Report Content"
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "value": "1O-Neb08ZvNQJRg-zJhIHBJQnlBeFp0EnHulzIxKubtc",
+          "mode": "list",
+          "cachedResultName": "주간업무보고_집계시트",
+          "cachedResultUrl": "https://docs.google.com/spreadsheets/d/1O-Neb08ZvNQJRg-zJhIHBJQnlBeFp0EnHulzIxKubtc/edit?usp=drivesdk"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "gid=0",
+          "mode": "list",
+          "cachedResultName": "시트1",
+          "cachedResultUrl": "https://docs.google.com/spreadsheets/d/1O-Neb08ZvNQJRg-zJhIHBJQnlBeFp0EnHulzIxKubtc/edit#gid=0"
+        },
+        "columns": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "date": "={{ $json.date }}",
+            "did": "={{ $json.did }}",
+            "todo": "={{ $json.todo }}",
+            "problem": "={{ $json.problem }}",
+            "name": "={{ $json.name }}",
+            "email": "={{ $json.email }}"
+          },
+          "matchingColumns": [],
+          "schema": [
+            {
+              "id": "name",
+              "displayName": "name",
+              "required": false,
+              "defaultMatch": false,
+              "display": true,
+              "type": "string",
+              "canBeUsedToMatch": true,
+              "removed": false
+            },
+            {
+              "id": "email",
+              "displayName": "email",
+              "required": false,
+              "defaultMatch": false,
+              "display": true,
+              "type": "string",
+              "canBeUsedToMatch": true,
+              "removed": false
+            },
+            {
+              "id": "date",
+              "displayName": "date",
+              "required": false,
+              "defaultMatch": false,
+              "display": true,
+              "type": "string",
+              "canBeUsedToMatch": true,
+              "removed": false
+            },
+            {
+              "id": "did",
+              "displayName": "did",
+              "required": false,
+              "defaultMatch": false,
+              "display": true,
+              "type": "string",
+              "canBeUsedToMatch": true,
+              "removed": false
+            },
+            {
+              "id": "todo",
+              "displayName": "todo",
+              "required": false,
+              "defaultMatch": false,
+              "display": true,
+              "type": "string",
+              "canBeUsedToMatch": true,
+              "removed": false
+            },
+            {
+              "id": "problem",
+              "displayName": "problem",
+              "required": false,
+              "defaultMatch": false,
+              "display": true,
+              "type": "string",
+              "canBeUsedToMatch": true,
+              "removed": false
+            }
+          ],
+          "attemptToConvertTypes": false,
+          "convertFieldsToString": false
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [
+        80,
+        -224
+      ],
+      "id": "8a03dc09-3eaf-4b33-ae90-53eb00644091",
+      "name": "Append Daily Report",
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "ADzpvtVWZXC2P7Rx",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "appendOrUpdate",
+        "documentId": {
+          "__rl": true,
+          "value": "1O-Neb08ZvNQJRg-zJhIHBJQnlBeFp0EnHulzIxKubtc",
+          "mode": "list",
+          "cachedResultName": "주간업무보고_집계시트",
+          "cachedResultUrl": "https://docs.google.com/spreadsheets/d/1O-Neb08ZvNQJRg-zJhIHBJQnlBeFp0EnHulzIxKubtc/edit?usp=drivesdk"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": 2011727439,
+          "mode": "list",
+          "cachedResultName": "마스터명단",
+          "cachedResultUrl": "https://docs.google.com/spreadsheets/d/1O-Neb08ZvNQJRg-zJhIHBJQnlBeFp0EnHulzIxKubtc/edit#gid=2011727439"
+        },
+        "columns": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "name": "={{ $json.name }}",
+            "email": "={{ $json.email }}"
+          },
+          "matchingColumns": [
+            "name"
+          ],
+          "schema": [
+            {
+              "id": "name",
+              "displayName": "name",
+              "required": false,
+              "defaultMatch": false,
+              "display": true,
+              "type": "string",
+              "canBeUsedToMatch": true,
+              "removed": false
+            },
+            {
+              "id": "email",
+              "displayName": "email",
+              "required": false,
+              "defaultMatch": false,
+              "display": true,
+              "type": "string",
+              "canBeUsedToMatch": true,
+              "removed": false
+            }
+          ],
+          "attemptToConvertTypes": false,
+          "convertFieldsToString": false
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [
+        80,
+        -80
+      ],
+      "id": "00428705-f884-4a74-b7bd-22f9cea760ab",
+      "name": "Update Master Roster",
+      "credentials": {
+        "googleSheetsOAuth2Api": {
+          "id": "ADzpvtVWZXC2P7Rx",
+          "name": "Google Sheets account"
+        }
+      }
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "Fetch Incoming Email": {
+      "main": [
+        [
+          {
+            "node": "Parse Work Report Content",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Work Report Content": {
+      "main": [
+        [
+          {
+            "node": "Append Daily Report",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Update Master Roster",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "bb1391f7-a46b-46fd-9c1f-3ebca2e61cfc",
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "14b9001adabf6161d9485d3d927e61058e0a5437f3866bd9ce2e79de5b4d79e2"
+  },
+  "id": "ytKKsYygBmWuIZEp",
+  "tags": []
+}


### PR DESCRIPTION
## 📌 개요
- 수신 메일을 파싱하여 Google Sheets에 자동 정리하는 에이전트의 기본 틀을 추가했습니다.
- 아직 최종본은 아니며, 기본 구조와 데이터 흐름을 공유드리고 피드백을 받고자 합니다.

## ✨ 주요 변경사항
- Function 노드에서 메일 본문을 파싱하여 `Did / To-Do / Problem` 추출
- `from` 값을 분리하여 `name`, `email` 필드 생성
- 메일 날짜를 `YYYY-MM-DD` 형식으로 변환하여 `$today`와의 비교를 단순화함  
  → 추후 당일 메일 미작성자를 식별해 미발송 알림 메일을 보낼 때 활용 예정
- Google Sheets에 업무보고 데이터를 Append
- Master Roster 시트에 신규 인원 추가 및 기존 인원 업데이트

## 📊 Google Sheets 구조
- **Weekly Report Sheet**
  - name, email, date, did, todo, problem
- **Master Roster Sheet**
  - name, email

## 🚧 진행 상황
- ✅ 기본 파싱 로직 구현
- ✅ Google Sheets Append / Update 동작 확인
- ⬜ 오후 6시 누락자/Problem 메일 발송 로직 연결
- ⬜ 주간 집계 및 KPT 자동화 연동